### PR TITLE
Valgrind ci dependencies fix

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -206,7 +206,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        sudo apt-get install -qq -y libc6-dbg
+        sudo apt update && sudo apt-get install -qq -y libc6-dbg
         mamba install -c conda-forge -c robostack-staging ycm-cmake-modules eigen valgrind ace sqlite
 
     - name: Download YARP [Linux&macOS]


### PR DESCRIPTION
Need to refresh packages in order to install libc6-dbg needed by valgrind. This fixes valgrind CI job 